### PR TITLE
Pin ansible cloud collection

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,3 +9,4 @@ roles:
 
 collections:
   - name: openstack.cloud
+    version: 1.10.0


### PR DESCRIPTION
Cloud collection >= 2.0.0 is only compatible with openstacksdk>=1.0.0. This conflicts with version installed by the openstacksdk role:

```
failed: [localhost] (item={'name': 'admin-vlan', 'project': 'admin', 'provider_network_type': 'vlan', 'provider_physical_network': 'physnet1', 'shared': False, 'subnets': [{
'name': 'admin-vlan', 'project': 'admin', 'cidr': '10.0.0.0/24', 'gateway_ip': '10.0.0.1', 'allocation_pool_start': '10.0.0.2', 'allocation_pool_end': '10.0.0.254'}]}) => {"
ansible_loop_var": "item", "changed": false, "item": {"name": "admin-vlan", "project": "admin", "provider_network_type": "vlan", "provider_physical_network": "physnet1", "sh
ared": false, "subnets": [{"allocation_pool_end": "10.0.0.254", "allocation_pool_start": "10.0.0.2", "cidr": "10.0.0.0/24", "gateway_ip": "10.0.0.1", "name": "admin-vlan", "
project": "admin"}]}, "msg": "Incompatible openstacksdk library found: Version MUST be >=1.0 and <=None, but 0.50.0 is smaller than minimum version 1.0."}                  
failed: [localhost] (item={'name': 'admin-provider', 'project': 'admin', 'provider_network_type': 'vlan', 'provider_physical_network': 'physnet1', 'provider_segmentation_id'
: 100, 'shared': False, 'subnets': [{'name': 'admin-provider', 'project': 'admin', 'cidr': '10.100.0.0/16', 'gateway_ip': '10.100.0.1', 'allocation_pool_start': '10.100.1.0'
, 'allocation_pool_end': '10.100.99.255'}]}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "admin-provider", "project": "admin", "provider_network_type"
: "vlan", "provider_physical_network": "physnet1", "provider_segmentation_id": 100, "shared": false, "subnets": [{"allocation_pool_end": "10.100.99.255", "allocation_pool_st
art": "10.100.1.0", "cidr": "10.100.0.0/16", "gateway_ip": "10.100.0.1", "name": "admin-provider", "project": "admin"}]}, "msg": "Incompatible openstacksdk library found: Ve
rsion MUST be >=1.0 and <=None, but 0.50.0 is smaller than minimum version 1.0."} 
```