### PR TITLE
Merge upstream openstack-config (inc. move to stackhpc.openstack collection)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,10 @@ ansible/collections/**/
 *~
 .*.swp
 .*sw?
+
+# Ignore working dirs
+ansible/openstack-config-image-cache
+ansible/openstack-config-venv
+
+# Ignore tmp output from template generation playbook
+generated-magnum-snippets/

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ ansible/collections/**/
 *~
 .*.swp
 .*sw?
+.vscode/
 
 # Ignore working dirs
 ansible/openstack-config-image-cache

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ packages. For example:
 
    $ virtualenv venv
    $ source venv/bin/activate
-   $ pip install -U pip
+   $ python -m pip install --upgrade pip
    $ pip install -r requirements.txt
 
 Install Ansible role and collection dependencies from Ansible Galaxy:

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,8 @@ variables in `etc/openstack-config.yml`
 
 .. code-block:: yaml
 
-   magnum_default_flavor_name: # Chosen flavor on target cloud
+   magnum_default_master_flavor_name: # Chosen flavor on target cloud
+   magnum_default_worker_flavor_name: # Chosen flavor on target cloud
    magnum_external_net_name: # External network
    magnum_loadbalancer_provider: # Octavia provider (e.g. 'ovn')
 

--- a/README.rst
+++ b/README.rst
@@ -76,3 +76,32 @@ configuration parameter:
 .. code-block::
 
    $ tools/openstack-config -- --vault-password-file config-secret.vault
+
+
+Magnum Cluster Templates
+========================
+
+To generate a new set of Magnum cluster templates and corresponding Glance image
+definitions which utilise the latest stable upstream release tag, set the following
+variables in `etc/openstack-config.yml`
+
+.. code-block:: yaml
+
+   magnum_flavor_name: # Chosen flavor on target cloud
+   magnum_external_net_name: # External network
+   magnum_loadbalancer_provider: # Octavia provider (e.g. 'ovn')
+
+then run the provided playbook with
+
+.. code-block:: bash
+
+   $ tools/openstack-config -p ansible/generate-magnum-capi-templates.yml
+
+This will create a ``generated-magnum-snippets`` directory in the repo root with
+a timestamped sub-directory containing an ``images.yml`` file and a ``templates.yml``
+file. The contents of these two files can then be added to any existing images and
+cluster templates in ``etc/openstack-config.yml``. When deploying the updated config,
+be sure to run the ``openstack-images.yml`` playbook *before* running the
+``openstack-container-clusters.yml`` playbook, otherwise the Magnum API will return
+an error referencing an invalid cluster type with image ``None``. This is handled
+automatically if running the full ``openstack.yml`` playbook.

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ variables in `etc/openstack-config.yml`
 
 .. code-block:: yaml
 
-   magnum_flavor_name: # Chosen flavor on target cloud
+   magnum_default_flavor_name: # Chosen flavor on target cloud
    magnum_external_net_name: # External network
    magnum_loadbalancer_provider: # Octavia provider (e.g. 'ovn')
 

--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,6 @@ packages. For example:
 Install Ansible role and collection dependencies from Ansible Galaxy:
 
 .. code-block::
-
-   $ ansible-galaxy role install \
-        -p ansible/roles \
-        -r requirements.yml
-
    $ ansible-galaxy collection install \
        -p ansible/collections \
        -r requirements.yml

--- a/ansible/generate-magnum-capi-templates.yml
+++ b/ansible/generate-magnum-capi-templates.yml
@@ -1,0 +1,46 @@
+---
+- name: Generate cluster templates
+  hosts: localhost
+  vars:
+    root_dir: ../
+  tasks:
+
+  - name: Fetch capi-helm-charts release information
+    ansible.builtin.uri:
+      url: https://api.github.com/repos/stackhpc/capi-helm-charts/releases/latest
+    register: capi_helm_chart_release_data
+
+  - name: Fetch dependencies.json for capi-helm-charts release
+    ansible.builtin.uri:
+      url: https://raw.githubusercontent.com/stackhpc/capi-helm-charts/{{ capi_helm_chart_release_data.json.tag_name }}/dependencies.json
+    register: dependencies_response
+
+  - name: Fetch manifest.json for capi-helm-charts images
+    # ansible.builtin.uri:
+    #   url: https://raw.githubusercontent.com/stackhpc/azimuth-images/{{ dependencies_response.json['azimuth-images'] }}/manifest.json
+    # Above URL returns 404 even though similar URL for capi-helm-charts repo works fine
+    # Not sure why but fall back to wget + JSON parsing for now.
+    shell: "wget -O - https://github.com/stackhpc/azimuth-images/releases/download/{{ dependencies_response.json['azimuth-images'] }}/manifest.json"
+    register: manifest_response
+    changed_when: false
+
+  - name: Parse JSON response
+    set_fact:
+      new_template_data: "{{ manifest_response.stdout | from_json | dict2items | selectattr('key', 'match', 'kubernetes*') | list }}"
+
+  - name: Ensure output dir exists
+    ansible.builtin.file:
+      path: "{{ [root_dir, 'generated-magnum-snippets', now(utc=true,fmt='%Y-%m-%d-T%H-%M-%S')] | path_join }}"
+      state: directory
+      mode: '0755'
+    register: output_dir
+
+  - name: Write new image config to file
+    template:
+      src: "magnum-capi-images.j2"
+      dest: "{{ output_dir.path }}/images.yml"
+
+  - name: Write new cluster template config to file
+    template:
+      src: "magnum-capi-templates.j2"
+      dest: "{{ output_dir.path }}/templates.yml"

--- a/ansible/generate-magnum-capi-templates.yml
+++ b/ansible/generate-magnum-capi-templates.yml
@@ -5,6 +5,14 @@
     root_dir: ../
   tasks:
 
+  - name: Check that required variables are defined
+    assert:
+      that:
+        - magnum_default_master_flavor_name is defined
+        - magnum_default_worker_flavor_name is defined
+        - magnum_external_net_name is defined
+        - magnum_loadbalancer_provider is defined
+
   - name: Fetch capi-helm-charts release information
     ansible.builtin.uri:
       url: https://api.github.com/repos/stackhpc/capi-helm-charts/releases/latest
@@ -14,6 +22,12 @@
     ansible.builtin.uri:
       url: https://raw.githubusercontent.com/stackhpc/capi-helm-charts/{{ capi_helm_chart_release_data.json.tag_name }}/dependencies.json
     register: dependencies_response
+
+  - name: Ensure wget packages is installed
+    become: true
+    package:
+      name: wget
+      state: present
 
   - name: Fetch manifest.json for capi-helm-charts images
     # ansible.builtin.uri:

--- a/ansible/group_vars/all/openstack
+++ b/ansible/group_vars/all/openstack
@@ -2,6 +2,10 @@
 ###############################################################################
 # Configuration of OpenStack user environment for OpenStack.
 
+# List of OpenStack domains. Format is as required by the stackhpc.os-projects
+# role.
+openstack_domains: []
+
 # List of OpenStack projects. Format is as required by the stackhpc.os-projects
 # role.
 openstack_projects: []

--- a/ansible/group_vars/all/openstack
+++ b/ansible/group_vars/all/openstack
@@ -21,6 +21,10 @@ openstack_routers: []
 # stackhpc.os-networks role.
 openstack_security_groups: []
 
+# List of RBAC definitions in the openstack projct. Format is as required by the
+# stackhpc.os-networks role.
+openstack_networks_rbac: []
+
 ###############################################################################
 # Configuration of nova flavors for OpenStack.
 

--- a/ansible/openstack-container-clusters.yml
+++ b/ansible/openstack-container-clusters.yml
@@ -5,7 +5,7 @@
     - container-clusters-templates
   roles:
     - role: stackhpc.openstack.os_container_clusters
-      os_container_clusters_venv: "{{ openstack_sdk_1_0_venv }}"
+      os_container_clusters_venv: "{{ openstack_venv }}"
       os_container_clusters_auth_type: "{{ openstack_auth_type }}"
       os_container_clusters_auth: "{{ openstack_auth }}"
       os_container_clusters_cacert: "{{ openstack_cacert }}"

--- a/ansible/openstack-container-clusters.yml
+++ b/ansible/openstack-container-clusters.yml
@@ -4,8 +4,8 @@
   tags:
     - container-clusters-templates
   roles:
-    - role: stackhpc.os-container-clusters
-      os_container_clusters_venv: "{{ openstack_venv }}"
+    - role: stackhpc.openstack.os_container_clusters
+      os_container_clusters_venv: "{{ openstack_sdk_1_0_venv }}"
       os_container_clusters_auth_type: "{{ openstack_auth_type }}"
       os_container_clusters_auth: "{{ openstack_auth }}"
       os_container_clusters_cacert: "{{ openstack_cacert }}"

--- a/ansible/openstack-flavors.yml
+++ b/ansible/openstack-flavors.yml
@@ -4,7 +4,7 @@
   tags:
     - flavors
   roles:
-    - role: stackhpc.os-flavors
+    - role: stackhpc.openstack.os_flavors
       os_flavors_venv: "{{ openstack_venv }}"
       os_flavors_auth_type: "{{ openstack_auth_type }}"
       os_flavors_auth: "{{ openstack_auth }}"

--- a/ansible/openstack-host-aggregates.yml
+++ b/ansible/openstack-host-aggregates.yml
@@ -4,7 +4,7 @@
   tags:
     - host_aggregates
   roles:
-    - role: stackhpc.os_host_aggregates
+    - role: stackhpc.openstack.os_host_aggregates
       os_host_aggregates_venv: "{{ openstack_venv }}"
       os_host_aggregates_auth_type: "{{ openstack_auth_type }}"
       os_host_aggregates_auth: "{{ openstack_auth }}"

--- a/ansible/openstack-images.yml
+++ b/ansible/openstack-images.yml
@@ -4,8 +4,8 @@
   tags:
     - images
   roles:
-    - role: stackhpc.os-images
-      os_images_venv: "{{ openstack_venv }}"
+    - role: stackhpc.openstack.os_images
+      os_images_venv: "{{ openstack_sdk_1_0_venv }}"
       os_images_cache: "{{ ansible_env.PWD }}/openstack-config-image-cache"
       os_images_auth_type: "{{ openstack_auth_type }}"
       os_images_auth: "{{ openstack_auth }}"

--- a/ansible/openstack-images.yml
+++ b/ansible/openstack-images.yml
@@ -5,7 +5,7 @@
     - images
   roles:
     - role: stackhpc.openstack.os_images
-      os_images_venv: "{{ openstack_sdk_1_0_venv }}"
+      os_images_venv: "{{ openstack_venv }}"
       os_images_cache: "{{ ansible_env.PWD }}/openstack-config-image-cache"
       os_images_auth_type: "{{ openstack_auth_type }}"
       os_images_auth: "{{ openstack_auth }}"

--- a/ansible/openstack-networks.yml
+++ b/ansible/openstack-networks.yml
@@ -12,3 +12,4 @@
       os_networks: "{{ openstack_networks }}"
       os_networks_routers: "{{ openstack_routers }}"
       os_networks_security_groups: "{{ openstack_security_groups }}"
+      os_networks_rbac: "{{ openstack_networks_rbac }}"

--- a/ansible/openstack-networks.yml
+++ b/ansible/openstack-networks.yml
@@ -4,7 +4,7 @@
   tags:
     - networks
   roles:
-    - role: stackhpc.os-networks
+    - role: stackhpc.openstack.os_networks
       os_networks_venv: "{{ openstack_venv }}"
       os_networks_auth_type: "{{ openstack_auth_type }}"
       os_networks_auth: "{{ openstack_auth }}"

--- a/ansible/openstack-project.yml
+++ b/ansible/openstack-project.yml
@@ -10,3 +10,4 @@
       os_projects_admin_auth: "{{ openstack_auth }}"
       os_projects_cacert: "{{ openstack_cacert }}"
       os_projects: "{{ openstack_projects }}"
+      os_projects_domains: "{{ openstack_domains }}"

--- a/ansible/openstack-project.yml
+++ b/ansible/openstack-project.yml
@@ -4,7 +4,7 @@
   tags:
     - project
   roles:
-    - role: stackhpc.os-projects
+    - role: stackhpc.openstack.os_projects
       os_projects_venv: "{{ openstack_venv }}"
       os_projects_auth_type: "{{ openstack_auth_type }}"
       os_projects_admin_auth: "{{ openstack_auth }}"

--- a/ansible/openstack.yml
+++ b/ansible/openstack.yml
@@ -1,8 +1,8 @@
 ---
-# Top level playbook that includes all others.
-#- import_playbook: openstack-project.yml
+#Top level playbook that includes all others.
+- import_playbook: openstack-project.yml
 - import_playbook: openstack-networks.yml
-#- import_playbook: openstack-flavors.yml
-#- import_playbook: openstack-images.yml
-#- import_playbook: openstack-host-aggregates.yml
-#- import_playbook: openstack-container-clusters.yml
+- import_playbook: openstack-flavors.yml
+- import_playbook: openstack-images.yml
+- import_playbook: openstack-host-aggregates.yml
+- import_playbook: openstack-container-clusters.yml

--- a/ansible/openstack.yml
+++ b/ansible/openstack.yml
@@ -1,8 +1,8 @@
 ---
 # Top level playbook that includes all others.
-- import_playbook: openstack-project.yml
+#- import_playbook: openstack-project.yml
 - import_playbook: openstack-networks.yml
-- import_playbook: openstack-flavors.yml
-- import_playbook: openstack-images.yml
-- import_playbook: openstack-host-aggregates.yml
-- import_playbook: openstack-container-clusters.yml
+#- import_playbook: openstack-flavors.yml
+#- import_playbook: openstack-images.yml
+#- import_playbook: openstack-host-aggregates.yml
+#- import_playbook: openstack-container-clusters.yml

--- a/ansible/openstack.yml
+++ b/ansible/openstack.yml
@@ -1,5 +1,5 @@
 ---
-#Top level playbook that includes all others.
+# Top level playbook that includes all others.
 - import_playbook: openstack-project.yml
 - import_playbook: openstack-networks.yml
 - import_playbook: openstack-flavors.yml

--- a/ansible/templates/magnum-capi-images.j2
+++ b/ansible/templates/magnum-capi-images.j2
@@ -1,0 +1,24 @@
+# Images required for corresponding Magnum cluster template
+# To make use of the generated config snippets, copy them to
+# etc/openstack-config and add the images to the openstack_images
+# list.
+
+# List snippet to add to existing openstack_images:
+{% for item in new_template_data %}
+# -{% raw %} "{{ {% endraw %}{{ item.value.name |  replace('-', '_') | replace('.', '_') }}{% raw %} }}"{% endraw %}
+
+{% endfor %}
+
+{% for item in new_template_data %}
+# Image for {{ item.key }}
+{{ item.value.name |  replace('-', '_') | replace('.', '_') }}:
+  name: "{{ item.value.name }}"
+  type: qcow2
+  image_url: "{{ item.value.url }}"
+  visibility: "community"
+  properties:
+    os_distro: "ubuntu"
+    os_version: "20.04"
+    kube_version: "{{ item.value.kubernetes_version }}"
+
+{% endfor %}

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -16,8 +16,8 @@
     capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
     octavia_provider: {{ magnum_loadbalancer_provider }}
   external_network_id: {{ magnum_external_net_name }}
-  master_flavor: {{ magnum_flavor_name }}
-  flavor: {{ magnum_flavor_name }}
+  master_flavor: {{ magnum_default_flavor_name }}
+  flavor: {{ magnum_default_flavor_name }}
   image: "{{ item.value.name }}"
   name: "{{ item.key }}"
   coe: "kubernetes"

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -1,0 +1,30 @@
+# Magnum cluster templates generated using latest upstream release tags
+# To make use of the generated config snippets, copy them to the 
+# openstack_container_clusters_templates list.
+
+# List snippet to add to existing openstack_container_clusters_templates:
+{% for item in new_template_data %}
+# -{% raw %} "{{ {% endraw %}{{ item.key | replace('-', '_') }}_{{ item.value.kubernetes_version | replace('.', '_') }}{% raw %} }}"{% endraw %}
+
+{% endfor %}
+
+{% for item in new_template_data %}
+{{ item.key | replace('-', '_') }}_{{ item.value.kubernetes_version | replace('.', '_') }}:
+  labels:
+    monitoring_enabled: "True"
+    kube_dashboard_enabled: "True"
+    capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
+    octavia_provider: {{ magnum_loadbalancer_provider }}
+  external_network_id: {{ magnum_external_net_name }}
+  master_flavor: {{ magnum_flavor_name }}
+  flavor: {{ magnum_flavor_name }}
+  image: "{{ item.value.name }}"
+  name: "{{ item.key }}"
+  coe: "kubernetes"
+  network_driver: "calico"
+  master_lb_enabled: "True"
+  floating_ip_enabled: "True"
+  dns_nameserver: "1.1.1.1,8.8.8.8,8.8.4.4"
+  public: True
+
+{% endfor %}

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -11,8 +11,8 @@
 {% for item in new_template_data %}
 {{ item.key | replace('-', '_') }}_{{ item.value.kubernetes_version | replace('.', '_') }}:
   labels:
-    monitoring_enabled: "True"
-    kube_dashboard_enabled: "True"
+    monitoring_enabled: "true"
+    kube_dashboard_enabled: "true"
     keystone_auth_enabled: "false"
     capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
     octavia_provider: {{ magnum_loadbalancer_provider }}

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -16,15 +16,15 @@
     capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
     octavia_provider: {{ magnum_loadbalancer_provider }}
   external_network_id: {{ magnum_external_net_name }}
-  master_flavor: {{ magnum_default_flavor_name }}
-  flavor: {{ magnum_default_flavor_name }}
+  master_flavor: {{ magnum_default_master_flavor_name }}
+  flavor: {{ magnum_default_worker_flavor_name }}
   image: "{{ item.value.name }}"
   name: "{{ item.key }}"
   coe: "kubernetes"
-  network_driver: "calico"
-  master_lb_enabled: "True"
-  floating_ip_enabled: "True"
-  dns_nameserver: "1.1.1.1,8.8.8.8,8.8.4.4"
-  public: True
+  network_driver: "{{ magnum_default_network_driver | default('calico') }}"
+  master_lb_enabled: "{{ magnum_master_lb_enabled | default('True') }}"
+  floating_ip_enabled: "{{ magnum_cluster_floating_ip_enabled | default('True') }}"
+  dns_nameserver: "{{ (magnum_cluster_default_dns_nameservers | default(['1.1.1.1', '8.8.8.8', '8.8.4.4'])) | join(',') }}"
+  public: "{{ magnum_cluster_templates_public | default('True') }}"
 
 {% endfor %}

--- a/ansible/templates/magnum-capi-templates.j2
+++ b/ansible/templates/magnum-capi-templates.j2
@@ -1,5 +1,5 @@
 # Magnum cluster templates generated using latest upstream release tags
-# To make use of the generated config snippets, copy them to the 
+# To make use of the generated config snippets, copy them to the
 # openstack_container_clusters_templates list.
 
 # List snippet to add to existing openstack_container_clusters_templates:
@@ -13,6 +13,7 @@
   labels:
     monitoring_enabled: "True"
     kube_dashboard_enabled: "True"
+    keystone_auth_enabled: "false"
     capi_helm_chart_version: "{{ capi_helm_chart_release_data.json.tag_name }}"
     octavia_provider: {{ magnum_loadbalancer_provider }}
   external_network_id: {{ magnum_external_net_name }}

--- a/etc/openstack-config/openstack-config.yml
+++ b/etc/openstack-config/openstack-config.yml
@@ -63,6 +63,37 @@
 # stackhpc.os-container-clusters role.
 #openstack_container_clusters_templates:
 
+# Configuration variables for generating new cluster template config.
+# These variables must be defined before using the generating new cluster
+# templates - see repo README for more details.
+
+# Must have at least 2 CPUs, 4GB RAM and 20GB disk
+# magnum_default_master_flavor_name:
+# magnum_default_worker_flavor_name:
+
+# Network to create tenant cluster FIPs on
+# magnum_external_net_name:
+
+# Provider for cluster loadbalancers (e.g. 'ovn')
+# magnum_loadbalancer_provider:
+
+# Kubernetes CNI to use for cluster templates (defaults to 'calico')
+# Must be one of the options supported by capi-helm-charts, see
+# https://github.com/stackhpc/capi-helm-charts/tree/main/charts/cluster-addons#container-network-interface-cni-plugins
+# magnum_default_network_driver:
+
+# Whether to create a master nodes loadbalancer for cluster templates (defaults to 'True')
+# magnum_master_lb_enabled:
+
+# Whether to add a floating IP to the loadbalancer for cluster templates (defaults to 'True')
+# magnum_cluster_floating_ip_enabled:
+
+# List of nameservers to use for cluster templates
+# magnum_cluster_default_dns_nameservers:
+
+# Whether generated cluster templates should be public by default (defaults to 'True')
+# magnum_cluster_templates_public:
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/openstack-config/openstack-config.yml
+++ b/etc/openstack-config/openstack-config.yml
@@ -63,7 +63,9 @@
 # stackhpc.os-container-clusters role.
 #openstack_container_clusters_templates:
 
-# Configuration variables for generating new cluster template config.
+###############################################################################
+# Configuration variables for generating new Magnum cluster template config.
+
 # These variables must be defined before using the generating new cluster
 # templates - see repo README for more details.
 

--- a/etc/openstack-config/openstack-config.yml
+++ b/etc/openstack-config/openstack-config.yml
@@ -2,6 +2,10 @@
 ###############################################################################
 # Configuration of OpenStack projects and users user environment.
 
+# List of OpenStack domains. Format is as required by the stackhpc.os-projects
+# role.
+#openstack_domains:
+
 # List of OpenStack projects. Format is as required by the stackhpc.os-projects
 # role.
 #openstack_projects:

--- a/etc/openstack-config/openstack-config.yml
+++ b/etc/openstack-config/openstack-config.yml
@@ -21,6 +21,10 @@
 # Format is as required by the stackhpc.os-networks role.
 #openstack_security_groups:
 
+# List of RBAC definitions in the openstack projct. Format is as required by the
+# stackhpc.os-networks role.
+#openstack_networks_rbac:
+
 ###############################################################################
 # Configuration of nova flavors.
 

--- a/examples/projects-octavia.yml
+++ b/examples/projects-octavia.yml
@@ -1,0 +1,29 @@
+---
+###############################################################################
+# Configuration of OpenStack user environment for OpenStack.
+
+# List of OpenStack projects. Format is as required by the stackhpc.os-projects
+# role.
+openstack_projects:
+  - "{{ openstack_service_project }}"
+
+# Definition of the openstack service project. Format is as required by the
+# stackhpc.os-projects role. Quotas are set to unlimited to avoid Octavia load
+# balancer creation failing on quota limits.
+openstack_service_project:
+  name: service
+  project_domain: default
+  user_domain: default
+  quotas: "{{ openstack_octavia_unlimited_quotas }}"
+
+# Dict of quotas to set for service project when Octavia is used.
+openstack_octavia_unlimited_quotas:
+  cores: -1
+  fixed_ips: -1
+  floatingip: -1
+  injected_file_size: -1
+  injected_files: -1
+  instances: -1
+  ram: -1
+  security_group: -1
+  security_group_rule: -1

--- a/examples/projects.yml
+++ b/examples/projects.yml
@@ -57,7 +57,6 @@ openstack_unlimited_quotas:
   backup_gigabytes: -1
   backups: -1
   cores: -1
-  fixed_ips: -1
   floatingip: -1
   gigabytes: -1
   injected_file_size: -1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-# Use Ansible 5 for consistent Rocky 9 behaviour when available, otherwise use Ansible 4
+# Use Ansible 5 for consistent Rocky 9 behaviour when available, otherwise use
+# Ansible 4
 ansible>=4,<5; python_version<"3.7"
 ansible>=5,<6; python_version>="3.7"

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: openstack.cloud
     version: 2.1.0
   - name: stackhpc.openstack
-    version: 0.1.0
+    version: 0.1.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,6 +3,4 @@ collections:
   - name: openstack.cloud
     version: 2.1.0
   - name: stackhpc.openstack
-    type: git
-    source: https://github.com/stackhpc/ansible-collection-openstack.git
-    version: 8a526f520b231ced3f5cf122a6c6fc241c03df73
+    version: 0.0.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: openstack.cloud
     version: 2.1.0
   - name: stackhpc.openstack
-    version: 0.0.1
+    version: 0.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,12 +1,8 @@
 ---
-roles:
-  - name: stackhpc.os-flavors
-  - name: stackhpc.os-images
-  - name: stackhpc.os-networks
-  - name: stackhpc.os-projects
-  - name: stackhpc.os_host_aggregates
-  - name: stackhpc.os-container-clusters
-
 collections:
   - name: openstack.cloud
-    version: '<2'
+    version: 2.1.0
+  - name: stackhpc.openstack
+    type: git
+    source: https://github.com/stackhpc/ansible-collection-openstack.git
+    version: 8a526f520b231ced3f5cf122a6c6fc241c03df73

--- a/tools/openstack-config
+++ b/tools/openstack-config
@@ -34,5 +34,4 @@ exec ansible-playbook \
   ${PLAYBOOK} \
   -i ansible/inventory \
   -e @etc/openstack-config/openstack-config.yml \
-  -e @etc/openstack-config/container-clusters.yml \
   $@

--- a/tools/openstack-config
+++ b/tools/openstack-config
@@ -34,4 +34,5 @@ exec ansible-playbook \
   ${PLAYBOOK} \
   -i ansible/inventory \
   -e @etc/openstack-config/openstack-config.yml \
+  -e @etc/openstack-config/container-clusters.yml \
   $@


### PR DESCRIPTION
- Wrap lines and add missing new line at end of file
- Prevent load balancer creation errors
- Add RBAC support into openstack-networks.yml
- add domains
- changes for ansible-collection-openstack
- separate venv is unnecessary now as all roles updated to new sdk
- change to official collection
- comments
- role install no longer needed
- Bump to stackhpc.openstack version 0.1.0
- Remove outdated fixed_ips option from example
- Add simplified Magnum template generation playbook
- Rename magnum_flavor_name -> magnum_default_flavor_name
- Address review feedback
- Add section partition
- Ignore vscode folder
- Disable keystone auth webhook by default
- Make labels lowercase
- feat!: bump `stackhpc.openstack` collection
