### PR TITLE
Bump stackhpc.openstack collection

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: openstack.cloud
     version: 2.4.1
   - name: stackhpc.openstack
-    version: 0.2.4
+    version: 0.4.1


### PR DESCRIPTION
This fixes a parsing error that requires loop labels to be strings which is raised from ansible-core 2.15 onwards, repeatedly breaking the periodic multinode https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/14210565526/job/39816863271

Tag diff is available here: https://github.com/stackhpc/ansible-collection-openstack/compare/0.2.4...0.4.1
